### PR TITLE
Adding `host_path` to config options

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule LokiLogger.MixProject do
   def project do
     [
       app: :loki_logger,
-      version: "0.3.0",
+      version: "0.3.1",
       elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
I use Grafana Cloud and the path is different there (`/loki/api/v1/push`) so adding the option to tweak it here.